### PR TITLE
Add dev script as alias for serve command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "CNCF Glossary.",
   "private": true,
   "scripts": {
+    "dev": "npm run serve",
     "__check:links": "make --keep-going check-links",
     "_build": "npm run _hugo -- -e dev -DEF --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "_check:links": "npm run __check:links",


### PR DESCRIPTION
Added a new "dev" script to package.json that runs the existing serve command.
This provides a more standard entry point for developers to start the local development environment.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=stellar-nest&projectId=474da9dce48a46dc8c283e98575d26a6)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>474da9dce48a46dc8c283e98575d26a6</projectId>-->